### PR TITLE
ZENREACH-555 Bumps version for hyperlink fix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-quill",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "The Quill rich-text editor as a React component.",
   "author": "zenoamaro <zenoamaro@gmail.com>",
   "homepage": "https://github.com/zenoamaro/react-quill",
@@ -37,7 +37,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "quill": "git+https://github.com/Wifast/quill.git#zenreach-1.0.12"
+    "quill": "git+https://github.com/Wifast/quill.git#zenreach-1.0.13"
   },
   "peerDependencies": {
     "react": ">=0.14.0"


### PR DESCRIPTION
Requires:
https://github.com/zenreach/quill/pull/5
